### PR TITLE
fix: correct converse-enhanced MCP classification from npm to local type

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -130,6 +130,7 @@ $mcpDefinitions = @(
         url = "https://github.com/justmy2satoshis/converse-mcp-enhanced.git"
         type = "python"
         description = "Multi-model AI with Ollama priority (80-95% savings)"
+        customPath = "src\server.py"
         env = @{
             OLLAMA_HOST = "http://localhost:11434"
             OPENAI_API_KEY = ""

--- a/verify_mcps.py
+++ b/verify_mcps.py
@@ -241,7 +241,7 @@ class MCPVerifier:
         print("   npm install -g @modelcontextprotocol/server-filesystem")
         print("   npm install -g @modelcontextprotocol/server-sqlite")
         print("   npm install -g server-perplexity-ask")
-        print("   npm install -g converse-mcp-server")
+        print("   # converse-enhanced is a GitHub Python MCP, not npm")
 
         print("\n2. Python command issues (Windows):")
         print("   Change 'python3' to 'python' in configuration")


### PR DESCRIPTION
- Add customPath to PowerShell installer for converse-enhanced pointing to src/server.py
- Fix verify_mcps.py comment to indicate converse-enhanced is a GitHub Python MCP, not npm
- Resolves 'Server disconnected' error for converse-enhanced MCP (1/15 failing)
- No changes to 14 working MCPs configuration